### PR TITLE
feat: add theory pages

### DIFF
--- a/ExamTrainer/app/build.gradle.kts
+++ b/ExamTrainer/app/build.gradle.kts
@@ -55,17 +55,20 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
 
     // Jetpack Compose dependencies
-    implementation("androidx.activity:activity-compose:1.8.0")
-    implementation("androidx.compose.ui:ui:1.6.0")
-    implementation("androidx.compose.foundation:foundation:1.6.0")
-    implementation("androidx.compose.material3:material3:1.1.2")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.5.4")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
-    implementation("androidx.activity:activity-ktx:1.8.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation(libs.activity.compose)
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.foundation)
+    implementation(libs.androidx.material3)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.activity.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
 
     // Icons
-    implementation("androidx.compose.material:material-icons-extended:1.5.0")
+    implementation(libs.androidx.material.icons.extended)
+
+    // Markdown
+    implementation(libs.compose.markdown)
 }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/domain/model/Theory.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/domain/model/Theory.kt
@@ -1,0 +1,11 @@
+package com.example.examtrainer.domain.model
+
+data class Section(
+    val title: String,
+    val content: String,
+)
+
+data class Chapter(
+    val title: String,
+    val sections: List<Section>,
+)

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/navigation/NavGraph.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/navigation/NavGraph.kt
@@ -9,9 +9,12 @@ import com.example.examtrainer.presentation.ui.MainScreen
 import com.example.examtrainer.presentation.ui.exercise.exam.ExamStartScreen
 import com.example.examtrainer.presentation.ui.exercise.exam.ExamQuestionScreen
 import com.example.examtrainer.presentation.ui.exercise.exam.ExamResultScreen
+import com.example.examtrainer.presentation.ui.theory.TheoryChaptersTOCScreen
 import com.example.examtrainer.presentation.ui.exercise.training.TrainingQuestionScreen
 import com.example.examtrainer.presentation.ui.exercise.training.TrainingResultScreen
 import com.example.examtrainer.presentation.ui.exercise.training.TrainingStartScreen
+import com.example.examtrainer.presentation.ui.theory.TheoryContentScreen
+import com.example.examtrainer.presentation.ui.theory.TheorySectionsTOCScreen
 
 @Composable
 fun NavGraph() {
@@ -39,7 +42,21 @@ fun NavGraph() {
             }
         }
         navigation(
-            startDestination =  NavRoutes.EXAM_START,
+            startDestination = NavRoutes.THEORY_CHAPTERS,
+            route = NavRoutes.THEORY_ROOT,
+        ) {
+            composable(NavRoutes.THEORY_CHAPTERS) {
+                TheoryChaptersTOCScreen(navController)
+            }
+            composable(NavRoutes.THEORY_SECTIONS) {
+                TheorySectionsTOCScreen(navController)
+            }
+            composable(NavRoutes.THEORY_CONTENT) {
+                TheoryContentScreen(navController)
+            }
+        }
+        navigation(
+            startDestination = NavRoutes.EXAM_START,
             route = NavRoutes.EXAM_ROOT
         ) {
             composable(NavRoutes.EXAM_START) {

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/navigation/NavRoutes.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/navigation/NavRoutes.kt
@@ -2,6 +2,10 @@ package com.example.examtrainer.presentation.navigation
 
 object NavRoutes {
     const val MAIN = "main"
+    const val THEORY_ROOT = "theory-root"
+    const val THEORY_CHAPTERS = "theory-chapters"
+    const val THEORY_SECTIONS = "theory-subsections"
+    const val THEORY_CONTENT = "theory-content"
     const val TRAINING_ROOT = "training-root"
     const val TRAINING_START = "training-start"
     const val TRAINING_QUESTION = "training-question"

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/CommonComponents.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/CommonComponents.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -40,7 +40,7 @@ fun CommonHeader(backButtonText: String, onClick: () -> Unit) {
                 .padding(vertical = 20.dp, horizontal = 30.dp)
         ) {
             Icon(
-                imageVector = Icons.Filled.ArrowBack,
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back",
                 tint = Color.Black,
                 modifier = Modifier.size(24.dp)

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/MainScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/MainScreen.kt
@@ -40,7 +40,12 @@ import com.example.examtrainer.presentation.navigation.NavRoutes
 
 
 @Composable
-fun TrainTypeButton(text: String, firstIcon: ImageVector, onClick: () -> Unit, modifier: Modifier = Modifier ) {
+fun TrainTypeButton(
+    text: String,
+    firstIcon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Button(
         onClick = onClick,
         modifier = modifier
@@ -53,7 +58,7 @@ fun TrainTypeButton(text: String, firstIcon: ImageVector, onClick: () -> Unit, m
         shape = RoundedCornerShape(10.dp), // Закругление углов
         elevation = ButtonDefaults.buttonElevation(4.dp) // Тень
     ) {
-        Row (
+        Row(
             modifier = Modifier
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
@@ -68,7 +73,7 @@ fun TrainTypeButton(text: String, firstIcon: ImageVector, onClick: () -> Unit, m
             Text(
                 text = text,
                 style = MaterialTheme.typography.bodySmall,
-                modifier =  Modifier.weight(1f),
+                modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Start
             )
             Icon(
@@ -117,13 +122,15 @@ fun MainScreen(navController: NavController) {
             verticalArrangement = Arrangement.spacedBy(50.dp, Alignment.CenterVertically)
         ) {
             StatisticWidget(
-                onClick = { navController.navigate(NavRoutes.TRAINING_ROOT) {
-                    launchSingleTop = true
-                } }
+                onClick = {
+                    navController.navigate(NavRoutes.TRAINING_ROOT) {
+                        launchSingleTop = true
+                    }
+                }
             )
 
             // Кнопка для выбора экзамена
-            Box (
+            Box(
                 modifier = Modifier
                     .width(275.dp)
                     .wrapContentHeight(Alignment.Top),
@@ -137,7 +144,7 @@ fun MainScreen(navController: NavController) {
                         contentColor = Color.White   // Цвет текста
                     )
                 ) {
-                    Row (
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
@@ -172,7 +179,8 @@ fun MainScreen(navController: NavController) {
                                 Text(
                                     text = exam.name,
                                     style = MaterialTheme.typography.labelLarge
-                                )},
+                                )
+                            },
                             onClick = {
                                 viewModel.selectExam(exam)
                                 isDropdownExpanded = false
@@ -182,45 +190,45 @@ fun MainScreen(navController: NavController) {
                 }
             }
 
-                TrainTypeButton(
-                    firstIcon = Icons.Filled.AutoStories,
-                    onClick = {
-                        navController.navigate(NavRoutes.TRAINING_ROOT) {
-                            launchSingleTop = true
-                        }
-                    },
-                    text = "Теория"
-                )
+            TrainTypeButton(
+                firstIcon = Icons.Filled.AutoStories,
+                onClick = {
+                    navController.navigate(NavRoutes.THEORY_ROOT) {
+                        launchSingleTop = true
+                    }
+                },
+                text = "Теория"
+            )
 
-                TrainTypeButton(
-                    firstIcon = Icons.Filled.NotificationImportant,
-                    onClick = {
-                        navController.navigate("exam-root") {
-                            launchSingleTop = true
-                        }
-                    },
-                    text = "Экзамен",
-                )
+            TrainTypeButton(
+                firstIcon = Icons.Filled.NotificationImportant,
+                onClick = {
+                    navController.navigate("exam-root") {
+                        launchSingleTop = true
+                    }
+                },
+                text = "Экзамен",
+            )
 
-                TrainTypeButton(
-                    firstIcon = Icons.Filled.School,
-                    onClick = {
-                        navController.navigate(NavRoutes.TRAINING_ROOT) {
-                            launchSingleTop = true
-                        }
-                    },
-                    text = "Тренировка"
-                )
+            TrainTypeButton(
+                firstIcon = Icons.Filled.School,
+                onClick = {
+                    navController.navigate(NavRoutes.TRAINING_ROOT) {
+                        launchSingleTop = true
+                    }
+                },
+                text = "Тренировка"
+            )
 
-                TrainTypeButton(
-                    firstIcon = Icons.Filled.ChecklistRtl,
-                    onClick = {
-                        navController.navigate(NavRoutes.TRAINING_ROOT) {
-                            launchSingleTop = true
-                        }
-                    },
-                    text = "По темам",
-                )
+            TrainTypeButton(
+                firstIcon = Icons.Filled.ChecklistRtl,
+                onClick = {
+                    navController.navigate(NavRoutes.TRAINING_ROOT) {
+                        launchSingleTop = true
+                    }
+                },
+                text = "По темам",
+            )
         }
     }
 }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/QuestionComponents.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/QuestionComponents.kt
@@ -22,12 +22,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun AnswersVariants(answers: List<String>, onSelectAnswer: (String) -> Unit, buttonBgColor: (String) -> Color) {
+fun AnswersVariants(
+    answers: List<String>,
+    onSelectAnswer: (String) -> Unit,
+    buttonBgColor: (String) -> Color
+) {
     Column(
         verticalArrangement = Arrangement.spacedBy(20.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        answers.forEachIndexed() { variantIndex, answer ->
+        answers.forEachIndexed { variantIndex, answer ->
             Button(
                 onClick = { onSelectAnswer(answer) },
                 modifier = Modifier
@@ -46,7 +50,7 @@ fun AnswersVariants(answers: List<String>, onSelectAnswer: (String) -> Unit, but
                     horizontalArrangement = Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text("${variantIndex+1}. ${answer}")
+                    Text("${variantIndex + 1}. $answer")
                 }
             }
         }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/exam/ExamStartScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/exam/ExamStartScreen.kt
@@ -17,7 +17,7 @@ import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
 import com.example.examtrainer.presentation.viewmodel.ExamViewModel
 
 @Composable
-fun ExamStartScreen (navController: NavController) {
+fun ExamStartScreen(navController: NavController) {
     val backStackEntry = rememberRootBackStackEntry(navController, NavRoutes.EXAM_ROOT)
     val viewModel: ExamViewModel = viewModel(backStackEntry)
 
@@ -38,9 +38,12 @@ fun ExamStartScreen (navController: NavController) {
 
         StartExerciseInfoBox(
             headerText = "Экзамен",
-            infoText = "Вам будет предложено N вопросов по всему курсу “Выбранный экзамен”.\n" +
-                    "\n" +
-                    "В ходе решения экзамена Вы не сможете получить подсказку по вопросу или посмотреть результат своего ответа.",
+            infoText =
+            """
+                Вам будет предложено N вопросов по всему курсу “Выбранный экзамен”.
+                
+                В ходе решения экзамена Вы не сможете получить подсказку по вопросу или посмотреть результат своего ответа.
+            """.trimIndent(),
             onStart = {
                 viewModel.startExam()
                 navController.navigate(NavRoutes.EXAM_QUESTION) {

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/training/TrainingQuestionScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/training/TrainingQuestionScreen.kt
@@ -86,7 +86,7 @@ fun TrainingQuestionScreen(navController: NavController) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         QuestionScreenHeader(
-            backButtonText= "Выход",
+            backButtonText = "Выход",
             onClick = {
                 navController.navigate(NavRoutes.MAIN) {
                     launchSingleTop = true // Запуск только одного экземпляра
@@ -99,7 +99,7 @@ fun TrainingQuestionScreen(navController: NavController) {
 
         // Область вопроса
         QuestionComponent(
-            currentQuestionNumber = index+1,
+            currentQuestionNumber = index + 1,
             questionsCount = questions.size,
             questionText = questions[index].text,
             isHintUsed = isHintUsed,
@@ -131,10 +131,10 @@ fun TrainingQuestionScreen(navController: NavController) {
                             viewModel.nextQuestion()
                         else {
                             viewModel.stopTraining()
-                            navController.navigate(NavRoutes.TRAINING_RESULT, {
+                            navController.navigate(NavRoutes.TRAINING_RESULT) {
                                 launchSingleTop = true
                                 restoreState = true
-                            })
+                            }
                         }
                     }
                 )
@@ -153,7 +153,7 @@ fun TrainingQuestionScreen(navController: NavController) {
 
 
 @Composable
-fun AnswersCountBox (count: Int, status: AnswerStatus) {
+fun AnswersCountBox(count: Int, status: AnswerStatus) {
     val boxColor = when (status) {
         AnswerStatus.Correct -> MaterialTheme.colorScheme.surface
         AnswerStatus.Wrong -> MaterialTheme.colorScheme.errorContainer
@@ -164,7 +164,8 @@ fun AnswersCountBox (count: Int, status: AnswerStatus) {
             .size(30.dp)
             .background(
                 color = boxColor,
-                shape = RoundedCornerShape(5.dp)),
+                shape = RoundedCornerShape(5.dp)
+            ),
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -176,7 +177,13 @@ fun AnswersCountBox (count: Int, status: AnswerStatus) {
 }
 
 @Composable
-fun QuestionScreenHeader(backButtonText: String, onClick: () -> Unit, time: Long, correctAnswersCount: Int, wrongAnswersCount: Int) {
+fun QuestionScreenHeader(
+    backButtonText: String,
+    onClick: () -> Unit,
+    time: Long,
+    correctAnswersCount: Int,
+    wrongAnswersCount: Int
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -204,7 +211,7 @@ fun QuestionScreenHeader(backButtonText: String, onClick: () -> Unit, time: Long
             )
         }
 
-        Row (
+        Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(5.dp)
         ) {
@@ -218,15 +225,27 @@ fun QuestionScreenHeader(backButtonText: String, onClick: () -> Unit, time: Long
         }
 
         Text(
-            text = String.format(Locale("ru", "RU"), "%02d:%02d:%02d", time / 3600, (time % 3600) / 60, time % 60),
+            text = String.format(
+                Locale("ru", "RU"),
+                "%02d:%02d:%02d",
+                time / 3600,
+                (time % 3600) / 60,
+                time % 60
+            ),
             style = MaterialTheme.typography.bodySmall
         )
     }
 }
 
 @Composable
-fun QuestionComponent(currentQuestionNumber: Int, questionsCount: Int, questionText: String, isHintUsed: Boolean, onClickHint: () -> Unit) {
-    Column (
+fun QuestionComponent(
+    currentQuestionNumber: Int,
+    questionsCount: Int,
+    questionText: String,
+    isHintUsed: Boolean,
+    onClickHint: () -> Unit
+) {
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .height(200.dp)
@@ -238,7 +257,7 @@ fun QuestionComponent(currentQuestionNumber: Int, questionsCount: Int, questionT
             modifier = Modifier
                 .fillMaxWidth()
                 .background(Color.LightGray)
-                .padding(top=10.dp, start = 10.dp),
+                .padding(top = 10.dp, start = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start
         ) {
@@ -252,7 +271,7 @@ fun QuestionComponent(currentQuestionNumber: Int, questionsCount: Int, questionT
             modifier = Modifier
                 .fillMaxWidth()
                 .background(Color.LightGray)
-                .padding(bottom=10.dp, end = 10.dp),
+                .padding(bottom = 10.dp, end = 10.dp),
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -262,7 +281,7 @@ fun QuestionComponent(currentQuestionNumber: Int, questionsCount: Int, questionT
                     .clip(RoundedCornerShape(100))
                     .background(MaterialTheme.colorScheme.onPrimary)
                     .padding(5.dp)
-                    .clickable (enabled = !isHintUsed) {
+                    .clickable(enabled = !isHintUsed) {
                         onClickHint()
                     }
             ) {

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/training/TrainingStartScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/training/TrainingStartScreen.kt
@@ -17,7 +17,7 @@ import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
 import com.example.examtrainer.presentation.viewmodel.TrainingViewModel
 
 @Composable
-fun TrainingStartScreen (navController: NavController) {
+fun TrainingStartScreen(navController: NavController) {
     val backStackEntry = rememberRootBackStackEntry(navController, NavRoutes.TRAINING_ROOT)
     val viewModel: TrainingViewModel = viewModel(backStackEntry)
 
@@ -38,9 +38,12 @@ fun TrainingStartScreen (navController: NavController) {
 
         StartExerciseInfoBox(
             headerText = "Тренировка",
-            infoText = "Вам будет предложено N вопросов по всему курсу “Выбранный экзамен”.\n" +
-                    "\n" +
-                    "В ходе решения экзамена Вы сможете получить подсказку по вопросу и посмотреть результат своего ответа.",
+            infoText =
+            """
+                Вам будет предложено N вопросов по всему курсу “Выбранный экзамен”.
+                
+                В ходе решения экзамена Вы сможете получить подсказку по вопросу и посмотреть результат своего ответа.
+            """.trimIndent(),
             onStart = {
                 viewModel.startTraining()
                 navController.navigate(NavRoutes.TRAINING_QUESTION) {

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TOC.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TOC.kt
@@ -1,18 +1,20 @@
 package com.example.examtrainer.presentation.ui.theory
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowRightAlt
-import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -26,6 +28,50 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.examtrainer.presentation.ui.CommonHeader
+
+@Composable
+fun TOC(
+    navController: NavController,
+    backButtonText: String,
+    backButtonRoute: String,
+    items: List<String>,
+    onItemClick: (Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CommonHeader(
+            backButtonText = backButtonText,
+            onClick = {
+                navController.navigate(backButtonRoute) {
+                    launchSingleTop = true
+                }
+            }
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(.9f)
+                .verticalScroll(ScrollState(0)),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            items.forEachIndexed { itemIdx, item ->
+                TOCDivider()
+                TOCButton(
+                    text = item,
+                    onClick = { onItemClick(itemIdx) },
+                )
+            }
+            TOCDivider()
+        }
+    }
+}
 
 @Composable
 fun TOCButton(text: String, onClick: () -> Unit) {

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TOCElements.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TOCElements.kt
@@ -2,12 +2,21 @@ package com.example.examtrainer.presentation.ui.theory
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowRightAlt
+import androidx.compose.material.icons.automirrored.filled.CompareArrows
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -24,25 +34,35 @@ fun TOCButton(text: String, onClick: () -> Unit) {
         shape = RectangleShape,
         modifier = Modifier
             .fillMaxWidth()
-            .height(60.dp),
+            .sizeIn(minHeight = 60.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.background,
             contentColor = Color.Black
         ),
     ) {
         Row(
-            modifier = Modifier.fillMaxSize(),
-            horizontalArrangement = Arrangement.Start,
+            modifier = Modifier
+                .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(text)
+            Text(
+                text = text,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Start
+            )
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "Select",
+                modifier = Modifier
+                    .size(24.dp)
+            )
         }
     }
 }
 
 @Composable
 fun TOCDivider() {
-    Divider(
+    HorizontalDivider(
         color = Color.Black,
         modifier = Modifier
             .fillMaxWidth()

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TOCElements.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TOCElements.kt
@@ -1,0 +1,51 @@
+package com.example.examtrainer.presentation.ui.theory
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TOCButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        shape = RectangleShape,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(60.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            contentColor = Color.Black
+        ),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text)
+        }
+    }
+}
+
+@Composable
+fun TOCDivider() {
+    Divider(
+        color = Color.Black,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp),
+    )
+}

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryChaptersTOCScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryChaptersTOCScreen.kt
@@ -1,0 +1,58 @@
+package com.example.examtrainer.presentation.ui.theory
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.examtrainer.presentation.navigation.NavRoutes
+import com.example.examtrainer.presentation.ui.CommonHeader
+import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
+import com.example.examtrainer.presentation.viewmodel.TheoryViewModel
+
+@Composable
+fun TheoryChaptersTOCScreen(navController: NavController) {
+    val backStackEntry = rememberRootBackStackEntry(navController, NavRoutes.THEORY_ROOT)
+    val viewModel: TheoryViewModel = viewModel(backStackEntry)
+
+    val chapters by viewModel.chapters.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+    ) {
+        CommonHeader(
+            backButtonText = "Главный экран",
+            onClick = {
+                navController.navigate(NavRoutes.MAIN) {
+                    launchSingleTop = true
+                }
+            }
+        )
+
+        chapters.forEachIndexed { chapterIdx, chapter ->
+            TOCDivider()
+            TOCButton(
+                text = chapter.title,
+                onClick = {
+                    viewModel.selectChapter(chapterIdx)
+                    navController.navigate(NavRoutes.THEORY_SECTIONS) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
+            )
+        }
+        TOCDivider()
+    }
+}
+

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryChaptersTOCScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryChaptersTOCScreen.kt
@@ -1,14 +1,17 @@
 package com.example.examtrainer.presentation.ui.theory
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -28,7 +31,8 @@ fun TheoryChaptersTOCScreen(navController: NavController) {
         modifier = Modifier
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.statusBars)
-            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.navigationBars),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CommonHeader(
             backButtonText = "Главный экран",
@@ -39,20 +43,26 @@ fun TheoryChaptersTOCScreen(navController: NavController) {
             }
         )
 
-        chapters.forEachIndexed { chapterIdx, chapter ->
-            TOCDivider()
-            TOCButton(
-                text = chapter.title,
-                onClick = {
-                    viewModel.selectChapter(chapterIdx)
-                    navController.navigate(NavRoutes.THEORY_SECTIONS) {
-                        launchSingleTop = true
-                        restoreState = true
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(.9f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            chapters.forEachIndexed { chapterIdx, chapter ->
+                TOCDivider()
+                TOCButton(
+                    text = chapter.title,
+                    onClick = {
+                        viewModel.selectChapter(chapterIdx)
+                        navController.navigate(NavRoutes.THEORY_SECTIONS) {
+                            launchSingleTop = true
+                            restoreState = true
+                        }
                     }
-                }
-            )
+                )
+            }
+            TOCDivider()
         }
-        TOCDivider()
     }
 }
 

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryChaptersTOCScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryChaptersTOCScreen.kt
@@ -1,22 +1,11 @@
 package com.example.examtrainer.presentation.ui.theory
 
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.examtrainer.presentation.navigation.NavRoutes
-import com.example.examtrainer.presentation.ui.CommonHeader
 import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
 import com.example.examtrainer.presentation.viewmodel.TheoryViewModel
 
@@ -27,42 +16,20 @@ fun TheoryChaptersTOCScreen(navController: NavController) {
 
     val chapters by viewModel.chapters.collectAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.statusBars)
-            .windowInsetsPadding(WindowInsets.navigationBars),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        CommonHeader(
-            backButtonText = "Главный экран",
-            onClick = {
-                navController.navigate(NavRoutes.MAIN) {
-                    launchSingleTop = true
-                }
-            }
-        )
+    val chapterNames = chapters.map { c -> c.title }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(.9f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            chapters.forEachIndexed { chapterIdx, chapter ->
-                TOCDivider()
-                TOCButton(
-                    text = chapter.title,
-                    onClick = {
-                        viewModel.selectChapter(chapterIdx)
-                        navController.navigate(NavRoutes.THEORY_SECTIONS) {
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                    }
-                )
+    TOC(
+        navController = navController,
+        backButtonText = "Главный экран",
+        backButtonRoute = NavRoutes.MAIN,
+        items = chapterNames,
+        onItemClick = { chapterIdx ->
+            viewModel.selectChapter(chapterIdx)
+            navController.navigate(NavRoutes.THEORY_SECTIONS) {
+                launchSingleTop = true
+                restoreState = true
             }
-            TOCDivider()
         }
-    }
+    )
 }
 

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryContentScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryContentScreen.kt
@@ -1,5 +1,8 @@
 package com.example.examtrainer.presentation.ui.theory
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -7,6 +10,9 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +26,7 @@ import com.example.examtrainer.presentation.navigation.NavRoutes
 import com.example.examtrainer.presentation.ui.CommonHeader
 import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
 import com.example.examtrainer.presentation.viewmodel.TheoryViewModel
+import dev.jeziellago.compose.markdowntext.MarkdownText
 
 @Composable
 fun TheoryContentScreen(navController: NavController) {
@@ -47,11 +54,12 @@ fun TheoryContentScreen(navController: NavController) {
             }
         )
 
-        Text(
+        MarkdownText(
+            markdown = content,
             modifier = Modifier
-                .padding(vertical = 10.dp, horizontal = 22.dp),
-            text = content,
-            style = MaterialTheme.typography.bodySmall
+                .padding(vertical = 10.dp, horizontal = 22.dp)
+                .verticalScroll(ScrollState(0)),
+            style = MaterialTheme.typography.bodySmall,
         )
     }
 }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryContentScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheoryContentScreen.kt
@@ -1,0 +1,59 @@
+package com.example.examtrainer.presentation.ui.theory
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.examtrainer.presentation.navigation.NavRoutes
+import com.example.examtrainer.presentation.ui.CommonHeader
+import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
+import com.example.examtrainer.presentation.viewmodel.TheoryViewModel
+
+@Composable
+fun TheoryContentScreen(navController: NavController) {
+    val backStackEntry = rememberRootBackStackEntry(navController, NavRoutes.THEORY_ROOT)
+    val viewModel: TheoryViewModel = viewModel(backStackEntry)
+
+    val chapters by viewModel.chapters.collectAsState()
+    val currentChapterIdx by viewModel.currentChapterIdx.collectAsState()
+    val currentSectionIdx by viewModel.currentSectionIdx.collectAsState()
+
+    val content = chapters[currentChapterIdx].sections[currentSectionIdx].content
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+    ) {
+        CommonHeader(
+            backButtonText = "Подразделы",
+            onClick = {
+                navController.navigate(NavRoutes.THEORY_SECTIONS) {
+                    launchSingleTop = true
+                }
+            }
+        )
+
+        Text(
+            modifier = Modifier
+                .padding(vertical = 10.dp, horizontal = 22.dp),
+            text = content,
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheorySectionsTOCScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheorySectionsTOCScreen.kt
@@ -4,17 +4,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.examtrainer.presentation.navigation.NavRoutes
@@ -36,7 +33,8 @@ fun TheorySectionsTOCScreen(navController: NavController) {
         modifier = Modifier
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.statusBars)
-            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.navigationBars),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CommonHeader(
             backButtonText = "Оглавление",
@@ -47,20 +45,26 @@ fun TheorySectionsTOCScreen(navController: NavController) {
             }
         )
 
-        sections.forEachIndexed { sectionIdx, section ->
-            TOCDivider()
-            TOCButton(
-                text = section.title,
-                onClick = {
-                    viewModel.selectSection(sectionIdx)
-                    navController.navigate(NavRoutes.THEORY_CONTENT) {
-                        launchSingleTop = true
-                        restoreState = true
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(.9f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            sections.forEachIndexed { sectionIdx, section ->
+                TOCDivider()
+                TOCButton(
+                    text = section.title,
+                    onClick = {
+                        viewModel.selectSection(sectionIdx)
+                        navController.navigate(NavRoutes.THEORY_CONTENT) {
+                            launchSingleTop = true
+                            restoreState = true
+                        }
                     }
-                }
-            )
+                )
+            }
+            TOCDivider()
         }
-        TOCDivider()
     }
 }
 

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheorySectionsTOCScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheorySectionsTOCScreen.kt
@@ -1,0 +1,67 @@
+package com.example.examtrainer.presentation.ui.theory
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.examtrainer.presentation.navigation.NavRoutes
+import com.example.examtrainer.presentation.ui.CommonHeader
+import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
+import com.example.examtrainer.presentation.viewmodel.TheoryViewModel
+
+@Composable
+fun TheorySectionsTOCScreen(navController: NavController) {
+    val backStackEntry = rememberRootBackStackEntry(navController, NavRoutes.THEORY_ROOT)
+    val viewModel: TheoryViewModel = viewModel(backStackEntry)
+
+    val chapters by viewModel.chapters.collectAsState()
+    val currentChapterIdx by viewModel.currentChapterIdx.collectAsState()
+
+    val sections = chapters[currentChapterIdx].sections
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+    ) {
+        CommonHeader(
+            backButtonText = "Оглавление",
+            onClick = {
+                navController.navigate(NavRoutes.THEORY_CHAPTERS) {
+                    launchSingleTop = true
+                }
+            }
+        )
+
+        sections.forEachIndexed { sectionIdx, section ->
+            TOCDivider()
+            TOCButton(
+                text = section.title,
+                onClick = {
+                    viewModel.selectSection(sectionIdx)
+                    navController.navigate(NavRoutes.THEORY_CONTENT) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
+            )
+        }
+        TOCDivider()
+    }
+}
+
+

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheorySectionsTOCScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/theory/TheorySectionsTOCScreen.kt
@@ -1,21 +1,11 @@
 package com.example.examtrainer.presentation.ui.theory
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.examtrainer.presentation.navigation.NavRoutes
-import com.example.examtrainer.presentation.ui.CommonHeader
 import com.example.examtrainer.presentation.ui.rememberRootBackStackEntry
 import com.example.examtrainer.presentation.viewmodel.TheoryViewModel
 
@@ -27,45 +17,21 @@ fun TheorySectionsTOCScreen(navController: NavController) {
     val chapters by viewModel.chapters.collectAsState()
     val currentChapterIdx by viewModel.currentChapterIdx.collectAsState()
 
-    val sections = chapters[currentChapterIdx].sections
+    val sectionNames = chapters[currentChapterIdx].sections.map { s -> s.title }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.statusBars)
-            .windowInsetsPadding(WindowInsets.navigationBars),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        CommonHeader(
-            backButtonText = "Оглавление",
-            onClick = {
-                navController.navigate(NavRoutes.THEORY_CHAPTERS) {
-                    launchSingleTop = true
-                }
+    TOC(
+        navController = navController,
+        backButtonText = "Оглавление",
+        backButtonRoute = NavRoutes.THEORY_CHAPTERS,
+        items = sectionNames,
+        onItemClick = { sectionIdx ->
+            viewModel.selectSection(sectionIdx)
+            navController.navigate(NavRoutes.THEORY_CONTENT) {
+                launchSingleTop = true
+                restoreState = true
             }
-        )
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(.9f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            sections.forEachIndexed { sectionIdx, section ->
-                TOCDivider()
-                TOCButton(
-                    text = section.title,
-                    onClick = {
-                        viewModel.selectSection(sectionIdx)
-                        navController.navigate(NavRoutes.THEORY_CONTENT) {
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                    }
-                )
-            }
-            TOCDivider()
         }
-    }
+    )
 }
 
 

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
@@ -36,9 +36,16 @@ class TheoryViewModel : ViewModel() {
                     Section(
                         "UNIX-подобные операционные системы",
                         """
-                            Какой-то контент
+                            ## UNIX-подобные операционные системы
                             
-                            Контент продолжается...
+                            **Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed aliquam tempor eros eget scelerisque. Etiam condimentum non nunc non porta. Aliquam eu risus neque. Phasellus pretium sit amet ipsum at aliquet. Cras vitae velit ut erat tincidunt suscipit ac ac nibh. Quisque vehicula mi eros, vel blandit elit imperdiet a. Donec ut lorem vitae lorem feugiat porta sit amet vel magna. Proin maximus ex nec nisl vehicula rutrum.**
+                            
+                            *Lorem ipsum dolor sit amet*:
+                            - Curabitur convallis;
+                            - Tellus quis convallis blandit;
+                            - Praesent lorem nunc.
+
+                            Praesent lorem nunc, sagittis non elit et, vestibulum ullamcorper erat. Mauris lorem orci, dapibus ut feugiat vel, mattis nec ipsum. Vivamus sit amet massa scelerisque, venenatis magna at, malesuada nisl. Donec nec volutpat felis. Donec non risus enim. Donec a magna nisl. Ut imperdiet auctor bibendum. Suspendisse pulvinar quis enim non laoreet. Mauris id consectetur dui, sed egestas sapien. Morbi viverra, urna et lobortis volutpat, tellus sem lobortis risus, non fermentum massa nunc pretium nibh. Etiam dapibus odio venenatis tempor gravida.
                         """.trimIndent()
                     ),
                     Section(

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
@@ -159,6 +159,10 @@ class TheoryViewModel : ViewModel() {
                     ),
                 ),
             ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
         )
     }
 }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
@@ -44,8 +44,11 @@ class TheoryViewModel : ViewModel() {
                             - Curabitur convallis;
                             - Tellus quis convallis blandit;
                             - Praesent lorem nunc.
-
+                            
                             Praesent lorem nunc, sagittis non elit et, vestibulum ullamcorper erat. Mauris lorem orci, dapibus ut feugiat vel, mattis nec ipsum. Vivamus sit amet massa scelerisque, venenatis magna at, malesuada nisl. Donec nec volutpat felis. Donec non risus enim. Donec a magna nisl. Ut imperdiet auctor bibendum. Suspendisse pulvinar quis enim non laoreet. Mauris id consectetur dui, sed egestas sapien. Morbi viverra, urna et lobortis volutpat, tellus sem lobortis risus, non fermentum massa nunc pretium nibh. Etiam dapibus odio venenatis tempor gravida.
+                            
+                            Pellentesque pulvinar diam quis ante rhoncus dignissim. Nam vel magna aliquam, dignissim erat sit amet, cursus quam. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Ut malesuada sodales ante, consequat viverra erat. Vestibulum at lacus vehicula, commodo nulla in, convallis sem. Sed id fermentum risus. Sed finibus in lacus vitae viverra. Aenean nec iaculis lacus. Duis pellentesque tincidunt ligula non eleifend. Nunc quis malesuada est, id elementum dui. Nunc faucibus tincidunt ligula. Integer arcu erat, bibendum a turpis eget, semper efficitur ipsum. Aliquam non elementum dolor. Cras hendrerit augue eu aliquet efficitur. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+
                         """.trimIndent()
                     ),
                     Section(
@@ -158,6 +161,54 @@ class TheoryViewModel : ViewModel() {
                         """.trimIndent()
                     ),
                 ),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
+            ),
+            Chapter(
+                title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",
+                sections = emptyList(),
             ),
             Chapter(
                 title = "Очень-очень-очень-очень-очень-очень-очень-очень длинное-длинное название главы",

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/TheoryViewModel.kt
@@ -1,0 +1,157 @@
+package com.example.examtrainer.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.example.examtrainer.domain.model.Chapter
+import com.example.examtrainer.domain.model.Section
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class TheoryViewModel : ViewModel() {
+    private val _chapters = MutableStateFlow<List<Chapter>>(emptyList())
+    val chapters: StateFlow<List<Chapter>> = _chapters
+
+    private val _currentChapterIdx = MutableStateFlow(0)
+    val currentChapterIdx: StateFlow<Int> = _currentChapterIdx
+
+    private val _currentSectionIdx = MutableStateFlow(0)
+    val currentSectionIdx: StateFlow<Int> = _currentSectionIdx
+
+    init {
+        loadData()
+    }
+
+    fun selectChapter(chapterIdx: Int) {
+        _currentChapterIdx.value = chapterIdx
+    }
+
+    fun selectSection(sectionIdx: Int) {
+        _currentSectionIdx.value = sectionIdx
+    }
+
+    private fun loadData() {
+        _chapters.value = listOf(
+            Chapter(
+                "Знакомство с ОС «Альт»",
+                listOf(
+                    Section(
+                        "UNIX-подобные операционные системы",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Проект GNU",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "ОС на основе ядра Linux",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "История ОС «Альт»",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Репозиторий Sisyphus (Сизиф)",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Продукция «Базальт СПО»",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                ),
+            ),
+            Chapter(
+                "Основы работы в командной строке",
+                listOf(
+                    Section(
+                        "Интерфейс командной строки",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Типы команд",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Терминалы",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Навигация по дереву каталогов",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "История команд",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Перенаправление консольного ввода-вывода",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Специальные символы командного интерпретатора",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                    Section(
+                        "Объединение выполнения команд",
+                        """
+                            Какой-то контент
+                            
+                            Контент продолжается...
+                        """.trimIndent()
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/ExamTrainer/gradle/libs.versions.toml
+++ b/ExamTrainer/gradle/libs.versions.toml
@@ -1,22 +1,44 @@
 [versions]
+activityCompose = "1.8.0"
+activityKtx = "1.8.0"
 agp = "8.8.1"
+composeMarkdown = "0.5.7"
+foundation = "1.6.0"
 kotlin = "1.9.24"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.6.1"
+lifecycleRuntimeKtx = "2.6.2"
+lifecycleViewmodelCompose = "2.6.2"
 material = "1.10.0"
 activity = "1.8.0"
 constraintlayout = "2.1.4"
+material3 = "1.1.2"
 material3Android = "1.3.1"
+navigationCompose = "2.7.7"
+materialIconsExtended = "1.5.0"
+ui = "1.6.0"
+uiToolingPreview = "1.5.4"
 
 [libraries]
+activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
+androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "foundation" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
+androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "uiToolingPreview" }
+compose-markdown = { module = "com.github.jeziellago:compose-markdown", version.ref = "composeMarkdown" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }

--- a/ExamTrainer/settings.gradle.kts
+++ b/ExamTrainer/settings.gradle.kts
@@ -16,6 +16,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // for markdown dependency
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
Closes #15 

Добавил страницы для теории: содержания для глав, подразделов, а также страницу контента подраздеа с поддержкой Markdown.

<img width="525" alt="image" src="https://github.com/user-attachments/assets/cbe7bd4f-2aea-4eff-b639-58b9a6a9477c" />
<img width="505" alt="image" src="https://github.com/user-attachments/assets/956f5e5e-6376-4f07-bec5-1b6d008e0e40" />
<img width="516" alt="image" src="https://github.com/user-attachments/assets/16ab257e-cf57-46fd-8907-d57a88941980" />
