### PR TITLE
feat: skip questions in training

### DIFF
--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/QuestionComponents.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/QuestionComponents.kt
@@ -5,19 +5,24 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -25,7 +30,8 @@ import androidx.compose.ui.unit.dp
 fun AnswersVariants(
     answers: List<String>,
     onSelectAnswer: (String) -> Unit,
-    buttonBgColor: (String) -> Color
+    buttonBgColor: (String) -> Color,
+    interactable: Boolean = true,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -33,7 +39,11 @@ fun AnswersVariants(
     ) {
         answers.forEachIndexed { variantIndex, answer ->
             Button(
-                onClick = { onSelectAnswer(answer) },
+                onClick = {
+                    if (interactable) {
+                        onSelectAnswer(answer)
+                    }
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .sizeIn(minHeight = 60.dp),
@@ -47,12 +57,12 @@ fun AnswersVariants(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical=10.dp, horizontal=5.dp),
+                        .padding(vertical = 10.dp, horizontal = 5.dp),
                     horizontalArrangement = Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = "${variantIndex+1}. $answer"
+                        text = "${variantIndex + 1}. $answer"
                     )
 
                 }
@@ -80,18 +90,19 @@ fun HintComponent(hintText: String, isHintUsed: Boolean) {
 }
 
 @Composable
-fun NextButton(text: String, onClick: () -> Unit) {
+fun TrainingButton(icon: ImageVector, onClick: () -> Unit, enabled: Boolean = true) {
     Button(
         onClick = {
             onClick()
         },
         shape = RoundedCornerShape(10.dp),
+        enabled = enabled,
     ) {
-        Text(
-            modifier = Modifier
-                .padding(vertical = 10.dp, horizontal = 22.dp),
-            text = text,
-            style = MaterialTheme.typography.bodySmall
+        Icon(
+            imageVector = icon,
+            contentDescription = "Navigation",
+            tint = Color.White,
+            modifier = Modifier.size(22.dp, 44.dp),
         )
     }
 }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/exam/ExamQuestionScreen.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/ui/exercise/exam/ExamQuestionScreen.kt
@@ -84,7 +84,7 @@ fun ExamQuestionScreen(navController: NavController) {
     if (showDialog) {
         ConfirmExitDialog(
             titleText = "Внимание",
-            text = "Вы уверенны что хотите закончить экзамен?",
+            text = "Вы уверены что хотите закончить экзамен?",
             onDismiss = {
                 showDialog = false
                 viewModel.resumeExercise()

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/exercise/BaseTrainingViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/exercise/BaseTrainingViewModel.kt
@@ -21,4 +21,9 @@ abstract class BaseTrainingViewModel : ExerciseViewModel() {
         super.nextQuestion()
         _isHintUsed.value = false
     }
+
+    override fun prevQuestion() {
+        super.prevQuestion()
+        _isHintUsed.value = false
+    }
 }

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/exercise/ExamViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/exercise/ExamViewModel.kt
@@ -60,7 +60,6 @@ class ExamViewModel @Inject constructor(
 
     override fun loadData() {
         _currentExam.value = examRepository.getSelectedExam()?.name
-//        println(currentExam)
         val questions = theoryRepository.getChapters(
             examRepository.getSelectedOrDefaultExam().name,
         )
@@ -83,15 +82,12 @@ class ExamViewModel @Inject constructor(
         super.stopExercise()
         viewModelScope.launch {
             successThreshold.collect { res ->
-//                println(res)
                 if (res) {
                     statsRepository.incrementGeneralStatField(examRepository.getSelectedExam()!!.name, StatsFields.passExams.name)
                 }
             }
         }
         statsRepository.incrementGeneralStatField(examRepository.getSelectedExam()!!.name, StatsFields.allExams.name)
-
-        println("stop Exercise")
     }
 
     override fun confirmAnswer() {

--- a/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/exercise/ExerciseViewModel.kt
+++ b/ExamTrainer/app/src/main/java/com/example/examtrainer/presentation/viewmodel/exercise/ExerciseViewModel.kt
@@ -115,6 +115,14 @@ abstract class ExerciseViewModel : ViewModel() {
         }
     }
 
+    open fun prevQuestion() {
+        if (_currentIndex.value > 0) {
+            _currentIndex.value -= 1
+            _selectedAnswer.value = null
+            _isAnswerConfirmed.value = false
+        }
+    }
+
     override fun onCleared() {
         _appLifecycleObserver.removeObserver()
     }


### PR DESCRIPTION
Closes #35 

Добавил возможность пропускать вопросы (переключаться влево-вправо) на тренировках. В экзаменах нужно обязательно выполнять последовательно, как и раньше.

<img width="457" alt="image" src="https://github.com/user-attachments/assets/1b6d2cb6-c7fd-4871-8405-1e354b0d4fc7" />

<img width="460" alt="image" src="https://github.com/user-attachments/assets/7ecbf76e-77b0-4b5c-b9d0-1b1fceec6769" />

<img width="494" alt="image" src="https://github.com/user-attachments/assets/882f460b-9be3-454a-935b-d809d4f094bc" />
